### PR TITLE
skip write only files

### DIFF
--- a/client.go
+++ b/client.go
@@ -86,6 +86,10 @@ func (c *Client) GetPattern(pattern string) (map[string]string, error) {
 		if info.IsDir() {
 			return nil
 		}
+		if info.Mode().Perm()&0400 == 0 {
+			// skip write only files
+			return nil
+		}
 		key := c.keyFromPath(path)
 		if !re.MatchString(key) {
 			return nil


### PR DESCRIPTION
skip write only files, for example: 

# ls -l /proc/sys/fs/binfmt_misc/register
--w------- 1 root root 0 Oct 27  2021 /proc/sys/fs/binfmt_misc/register
It would interrupt filepath.Walk.
